### PR TITLE
Add flash events endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ const upload = multer({ dest: 'uploads/' });
 // Routes
 app.use('/api/games', require('./routes/games'));
 app.use('/api/flashes', require('./routes/flashes'));
+app.use('/api/flash-events', require('./routes/flash-events'));
 app.use('/api/analysis', require('./routes/analysis'));
 
 // Serve React app in production

--- a/server/routes/flash-events.js
+++ b/server/routes/flash-events.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+const database = require('../models/database');
+
+// GET /api/flash-events/:matchId - Retrieve flash events for a match
+router.get('/:matchId', (req, res) => {
+  const query = `
+    SELECT participantId, summonerName, championName, timestamp,
+           classification, confidenceScore, startPosX, startPosY,
+           endPosX, endPosY
+    FROM FlashEvents
+    WHERE matchId = ?
+    ORDER BY timestamp ASC
+  `;
+
+  database.getDb().all(query, [req.params.matchId], (err, rows) => {
+    if (err) {
+      res.status(500).json({ error: err.message });
+      return;
+    }
+    res.json(rows);
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `GET /api/flash-events/:matchId` endpoint to fetch flash events for a match
- wire new flash-events route into Express server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f8dbf01f4833299a65fb766b3d25a